### PR TITLE
Redis configuration

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -12,7 +12,14 @@ class RedisClient
 private
 
   def config
-    YAML.load_file(Rails.root.join("config", "redis.yml"))
+    if ENV['QUIRKAFLEEG_SIGNON_REDIS_HOST']
+      {
+        host:     ENV['QUIRKAFLEEG_SIGNON_REDIS_HOST'],
+        password: ENV['QUIRKAFLEEG_SIGNON_REDIS_PASSWORD'],
+      }
+    else
+      YAML.load_file(Rails.root.join("config", "redis.yml"))
+    end
   end
 
 end


### PR DESCRIPTION
This should make the sidekiq redis connection use config from environment variables (which are already set in the chef env).
